### PR TITLE
fix(security): add dependabot, use GHA SHA values

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    cooldown:
+      default-days: 30
+
+  - package-ecosystem: conda
+    directory: /
+    schedule:
+      interval: monthly
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"
+    cooldown:
+      default-days: 30

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -13,11 +13,11 @@ jobs:
     env:
       DOCKER_BUILDKIT: true
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Execute linters and test suites
         run: ./docker/cibuild
       - name: Upload All coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml
@@ -32,21 +32,21 @@ jobs:
       run:
         shell: bash -l {0}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up conda cache
-        uses: actions/cache@v2
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/conda_pkgs_dir
           key: ${{ runner.os }}-conda-${{ hashFiles('**/environment.yml') }}
           restore-keys: ${{ runner.os }}-conda-
       - name: Set up pip cache
-        uses: actions/cache@v2
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('pyproject.toml') }}
           restore-keys: ${{ runner.os }}-pip-
       - name: Set up Conda with Python ${{ matrix.python-version }}
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5 # v4.0.1
         with:
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,10 +11,10 @@ jobs:
     name: release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Python 3.x
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.x"
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 - Owner: @jjfrench @omshinde
 - STAC extensions used:
   - [proj](https://github.com/stac-extensions/projection/)
-  - [pointcloud](htts://github.com/stac-extensions/pointcloud/)
+  - [pointcloud](https://github.com/stac-extensions/pointcloud/)
 
 ## STAC examples
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,8 +16,8 @@ COPY src/stactools/gedi_calval_copc/__init__.py src/stactools/gedi_calval_copc/
 RUN apt-get -y -q update \
     && apt-get -y -q install build-essential \
     && rm -rf /var/lib/apt/lists/
-RUN pip install .
-RUN rm -r /opt/conda/lib/python3.11/site-packages/stactools/gedi_calval_copc
+RUN pip install . \
+    && rm -rf /opt/conda/lib/python*/site-packages/stactools/gedi_calval_copc
 
 
 FROM dependencies as builder

--- a/environment.yml
+++ b/environment.yml
@@ -9,4 +9,4 @@ dependencies:
   - conda-forge::libstdcxx-ng # gdal dependency. Make sure it's from the same channel as gdal
   - conda-forge::pdal
   - conda-forge::python-pdal
-  - conda-forge::pyproj==3.5.0 # Python 3.8 compatibility
+  - conda-forge::pyproj>=3.6.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,19 +16,19 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Natural Language :: English",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dependencies = [
     "stactools>=0.4.0",
     "s3fs", 
     "requests",
     "pdal",
     "python-pdal",
-    "pyproj==3.5.0"
+    "pyproj>=3.6.0"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Description

- adds dependabot once a month, groups by package dependencies and GitHub actions, uses a cooldown period to ensure we're not using new vulnerabilities - this won't affect dependabot's security updates
- swaps GitHub action version tags to SHA values